### PR TITLE
[#82] Implementation of /api/export route for CSV export

### DIFF
--- a/eis-tracker/app/api/export/route.ts
+++ b/eis-tracker/app/api/export/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+    return NextResponse.json({ message: "Export API working!" });
+}


### PR DESCRIPTION
✅ Implemented the `/api/export` route to begin CSV export functionality.

### Changes:
- Created a new API route at `/api/export`.
- This route currently returns `{ message: "Export API working!" }` as a placeholder.
- This lays the foundation for exporting logs to CSV.

Closes #82 
References #82  
