### PR TITLE
[#83] Extract logs from database and generate CSV

### DIFF
--- a/eis-tracker/app/api/export/route.ts
+++ b/eis-tracker/app/api/export/route.ts
@@ -7,7 +7,7 @@ import path from "path";
  * Converts a timestamp (milliseconds) to a human-readable format.
  * Wraps values in double quotes to prevent Excel from auto-formatting.
  */
-const formatValue = (value: any) => `"${value !== null ? value : "N/A"}"`; 
+const formatValue = (value: string | number | null | undefined) => `"${value !== null ? value : "N/A"}"`; 
 const formatDate = (timestamp: number | null) => `"${timestamp ? new Date(timestamp).toLocaleString() : "N/A"}"`;
 
 /**
@@ -18,8 +18,13 @@ export async function GET() {
         // Connect to the SQLite database
         const db = new Database("database/database.db");
 
-        // Fetch all logs from the database
-        const logs = db.prepare("SELECT LogID, User AS StudentID, Time_In, Time_Out FROM logs").all();
+        // Fetch all logs from the database with correct type definition
+        const logs = db.prepare("SELECT LogID, User AS StudentID, Time_In, Time_Out FROM logs").all() as Array<{
+            LogID: number;
+            StudentID: number;
+            Time_In: number | null;
+            Time_Out: number | null;
+        }>;
 
         // Add BOM (Byte Order Mark) to fix Excel auto-formatting issues
         let csvContent = `\uFEFF"LogID","StudentID","Time_In","Time_Out"\n`; // CSV Header with BOM

--- a/eis-tracker/app/api/export/route.ts
+++ b/eis-tracker/app/api/export/route.ts
@@ -1,5 +1,47 @@
 import { NextResponse } from "next/server";
+import Database from "better-sqlite3";
+import { writeFileSync } from "fs";
+import path from "path";
 
+/**
+ * Converts a timestamp (milliseconds) to a human-readable format.
+ * Wraps values in double quotes to prevent Excel from auto-formatting.
+ */
+const formatValue = (value: any) => `"${value !== null ? value : "N/A"}"`; 
+const formatDate = (timestamp: number | null) => `"${timestamp ? new Date(timestamp).toLocaleString() : "N/A"}"`;
+
+/**
+ * Handles GET requests to export logs from the database as a CSV file.
+ */
 export async function GET() {
-    return NextResponse.json({ message: "Export API working!" });
+    try {
+        // Connect to the SQLite database
+        const db = new Database("database/database.db");
+
+        // Fetch all logs from the database
+        const logs = db.prepare("SELECT LogID, User AS StudentID, Time_In, Time_Out FROM logs").all();
+
+        // Add BOM (Byte Order Mark) to fix Excel auto-formatting issues
+        let csvContent = `\uFEFF"LogID","StudentID","Time_In","Time_Out"\n`; // CSV Header with BOM
+
+        logs.forEach(log => {
+            csvContent += `${formatValue(log.LogID)},${formatValue(log.StudentID)},${formatDate(log.Time_In)},${formatDate(log.Time_Out)}\n`;
+        });
+
+        // Define the file path to save the CSV
+        const filePath = path.join(process.cwd(), "public", "logs.csv");
+
+        // Save the CSV file with UTF-8 encoding
+        writeFileSync(filePath, csvContent, { encoding: "utf-8" });
+
+        // Close the database connection
+        db.close();
+
+        // Return a download link
+        return NextResponse.json({ message: "Logs exported successfully!", downloadUrl: "/logs.csv" });
+
+    } catch (error) {
+        console.error("Error exporting logs:", error);
+        return NextResponse.json({ message: "Failed to export logs" }, { status: 500 });
+    }
 }


### PR DESCRIPTION
✅ Implemented the `/api/export` route to extract logs from the database and generate a downloadable CSV file.

### Changes:
- Queried the `logs` table from `database.db` to retrieve `LogID`, `StudentID`, `Time_In`, and `Time_Out`.
- Converted timestamps to a readable format for better Excel compatibility.
- Ensured `Time_Out` displays `"N/A"` when null.
- Stored the CSV file in `/public/logs.csv`.
- API response now includes a valid download link.

This ensures that logs are properly retrieved from the database and can be downloaded in a structured CSV format.

### ✅ Acceptance Criteria:
- The API successfully fetches logs from `database.db`
- Data is formatted correctly (`LogID, StudentID, Time_In, Time_Out`)
- CSV file is generated and stored in `/public/logs.csv`
- The API response provides a valid download link

Closes #83  
References #83
