### PR TITLE
[#84] Added CSV download button to admin page

### DIFF
--- a/eis-tracker/app/admin/page.tsx
+++ b/eis-tracker/app/admin/page.tsx
@@ -10,6 +10,7 @@ export default function Page() {
     const [green, setGreen] = useState(false);
     const [orange, setOrange] = useState(false);
     const [admin, setAdmin] = useState(false);
+    const [isDownloading, setIsDownloading] = useState(false);
 
     const register = async () => {
         let res = await fetch('', {
@@ -47,6 +48,33 @@ export default function Page() {
             console.error('Failed to update tags');
         }
     }
+
+    const handleDownload = async () => {
+        setIsDownloading(true);
+        try {
+            // Fetch the CSV export link from the API
+            const response = await fetch("/api/export");
+            const data = await response.json();
+
+            if (response.ok && data.downloadUrl) {
+                // Create a link and trigger download
+                const link = document.createElement("a");
+                link.href = data.downloadUrl;
+                link.setAttribute("download", "logs.csv");
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+            } 
+	    else {
+                alert("Failed to download logs.");
+            }
+        } 
+        catch (error) {
+            console.error("Error downloading logs:", error);
+            alert("An error occurred while downloading logs.");
+        }
+        setIsDownloading(false);
+    };
 
     useEffect(() => {
         // Make a fetch request to the API route
@@ -145,6 +173,14 @@ export default function Page() {
                     Update User
                 </button>
             </div>
+
+	    <button
+                onClick={handleDownload}
+                disabled={isDownloading}
+                className="mt-6 px-6 py-3 bg-green-500 text-white text-lg rounded-md hover:bg-green-600 transition disabled:opacity-50"
+            >
+                {isDownloading ? "Downloading..." : "Download Logs"}
+            </button>
 
         </div>
 


### PR DESCRIPTION
✅ Added a CSV download button to the admin page.

Changes:
- Added a button to `/admin` that triggers a request to `/api/export`
- The button automatically downloads the CSV file on success
- Displays an alert if the download fails

✅ Acceptance Criteria:
- Button exists on the admin page
- Clicking it triggers a request to `/api/export`
- The CSV file downloads automatically
- An alert appears if the download fails

Closes #84  
References #81