### PR TITLE
[#131] Fix tag display on homepage after CSV import

### DIFF
--- a/eis-tracker/app/api/db/route.ts
+++ b/eis-tracker/app/api/db/route.ts
@@ -100,7 +100,21 @@ export async function GET(request: Request) {
       'OrangeTag BOOLEAN DEFAULT FALSE)').run();
 
     // Query the users table
-    const users = db.prepare('SELECT * FROM users').all();
+    // Join users with training_data and compute Tags from training data eligibility
+    const users = db.prepare(`
+      SELECT 
+        u.StudentID,
+        u.First_Name,
+        u.Last_Name,
+        u.Logged_In,
+        COALESCE(td.WhiteTag, 0) * 1 +
+        COALESCE(td.BlueTag, 0) * 2 +
+        COALESCE(td.GreenTag, 0) * 4 +
+        COALESCE(td.OrangeTag, 0) * 8 AS Tags
+      FROM users u
+      LEFT JOIN training_data td ON u.StudentID = td.StudentID
+    `).all();
+
     const logs = db.prepare('SELECT * FROM logs').all();
 
 


### PR DESCRIPTION
Fixes an issue where student tag colors were not showing on the homepage after uploading a Canvas CSV. 

Changes:
- Updated `/api/db/route.ts` to include training_data join when returning user data
- Mapped tag values from training_data to the `Tags` field so existing UI correctly renders color boxes

✅ Acceptance Criteria:
- Students with tag values in training_data now display white, blue, green, or orange boxes
- CSV-imported students can log in and display proper tag status
- Homepage fetch request loads the combined user + tag data as expected

Closes #131 
