### PR TITLE
[#133] Improve Display Page Tiling Layout to Support 20 Logged-In Students

### DIFF
--- a/eis-tracker/app/display/page.tsx
+++ b/eis-tracker/app/display/page.tsx
@@ -12,7 +12,7 @@ interface Student {
 export default function Dashboard() {
     const [loggedInStudents, setLoggedInStudents] = useState<Student[]>([]);
 
-    const imagePath = `/blankimage.png`;
+    const imagePath = `/s25-sis/blankimage.png`;
 
     // Helper function to render colored tag boxes
     const renderTags = (tags: number) => {
@@ -59,26 +59,32 @@ export default function Dashboard() {
     }, []);
 
     return (
-        <div className="flex flex-col items-center justify-center min-h-screen p-8 bg-white">
+        <div className="flex flex-col items-center justify-center min-h-screen p-12 bg-white">
             <h2 className="text-2xl font-bold mb-4">Currently Logged In</h2>
-            <ul className="w-full max-w-2xl">
-                {loggedInStudents.filter(student => student.Logged_In).map(student => (
-                    <li key={student.StudentID} className="flex items-center space-x-4 border p-4 rounded shadow-md mb-2">
+            <div
+                className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-6 2xl:grid-cols-7 gap-6 w-full max-w-[90vw]">
+                {loggedInStudents
+                    .filter(student => student.Logged_In)
+                    .sort((a, b) => a.First_Name.localeCompare(b.First_Name))
+                    .map(student => (
+                        <div key={student.StudentID}
+                         className="flex flex-col items-center border p-8 rounded shadow-md bg-gray-50 transition-transform duration-300 hover:scale-105">
                         <img
-                            src={imagePath}
-                            alt={`${student.First_Name}'s Profile`}
-                            className="w-12 h-12 rounded-full object-cover"
+                            src={`/photos/${student.StudentID}.png`}
+                            alt="Profile image"
+                            className="w-20 h-20 rounded-full object-cover"
+                            onError={(e) => {
+                                e.currentTarget.onerror = null;
+                                e.currentTarget.src = imagePath; // fallback to blank image
+                            }}
                         />
-                        <div>
-                            <strong>First Name:</strong> {student.First_Name}
+                        <div className="text-center mt-4">
+                            <div className="text-xl font-bold">{student.First_Name}</div>
+                            <div className="mt-2 scale-125">{renderTags(parseInt(student.Tags))}</div>
                         </div>
-                        <div>
-                            <strong>Tags:</strong>
-                            {renderTags(parseInt(student.Tags))}
-                        </div>
-                    </li>
+                    </div>
                 ))}
-            </ul>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
✅ Improves the display page to support up to 20 logged-in students in a clean, scrollable, and responsive layout.

Changes:
Converted logged-in list to a responsive grid using Tailwind (grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5)

Enlarged student profile photos for better visibility from wall-mounted monitors

Ensured layout wraps properly and scrolls if necessary

Sorts logged-in students alphabetically by name

Includes future planning consideration for distinguishing supervisors/admins

✅ Acceptance Criteria:
Up to 20 students appear clearly on screen

Layout adapts based on screen size (responsive tiling)

Tag boxes display correctly

Student name and image are readable from a distance

System performs well without flickering or broken images

Closes #133 