### PR TITLE
[#176] Use in-memory buffer reading for CSV import instead of temp files

### DIFF
--- a/eis-tracker/app/admin/page.tsx
+++ b/eis-tracker/app/admin/page.tsx
@@ -462,7 +462,8 @@ export default function Page() {
 
         createTable();
         fetchData();
-    });
+    }, []); // ✅ Prevents infinite re-renders
+
 
 
     const openRegister = () => {

--- a/eis-tracker/app/api/import/route.ts
+++ b/eis-tracker/app/api/import/route.ts
@@ -1,5 +1,4 @@
 import {NextRequest, NextResponse} from 'next/server';
-import * as fs from 'fs';
 import csv from 'csv-parser';
 import Database from 'better-sqlite3';
 import { Readable } from 'stream';

--- a/eis-tracker/app/api/import/route.ts
+++ b/eis-tracker/app/api/import/route.ts
@@ -1,7 +1,6 @@
 import {NextRequest, NextResponse} from 'next/server';
 import * as fs from 'fs';
 import csv from 'csv-parser';
-import path from 'path';
 import Database from 'better-sqlite3';
 import { Readable } from 'stream';
 
@@ -21,51 +20,6 @@ export const config = {
     api: {
         bodyParser: false,
     },
-};
-
-// Function to extract relevant data from CSV
-const extractDataFromCSV = async (filePath: string): Promise<StudentData[]> => {
-    const results: StudentData[] = [];
-    let firstRowProcessed = false;
-
-    // Using a Promise wrapper around the stream process
-    return new Promise((resolve, reject) => {
-        const stream = fs.createReadStream(filePath).pipe(csv());
-
-        stream
-            .on('data', (row: { [key: string]: string }) => {
-                if (!firstRowProcessed) {
-                    firstRowProcessed = true;
-                    return; // Skip the first row
-                }
-
-                if (row['Student'] === 'Student, Test') {
-                    return; // Skip the test student row
-                }
-
-                const fullName = row['Student'];
-                const [lastName, firstName] = fullName.split(',').map((name: string) => name.trim());
-
-                const studentData: StudentData = {
-                    firstName: firstName || '',
-                    lastName: lastName || '',
-                    StudentID: row['SIS User ID'] || '',
-                    blueTag: Number(row['BLUE TAG  (228139)']) === 1,
-                    greenTag: Number(row['GREEN TAG (293966)']) === 100,
-                    orangeTag: Number(row['ORANGE TAG (294239)']) === 100,
-                    whiteTag: Number(row['Training Affirmation (Required)  (228040)']) === 100,
-                };
-
-                results.push(studentData);
-            })
-            .on('end', () => {
-                results.pop(); // Remove the last test student
-                resolve(results); // Resolve the promise with the final results
-            })
-            .on('error', (err) => {
-                reject(err); // Reject the promise in case of error
-            });
-    });
 };
 
 const extractDataFromBuffer = async (buffer: ArrayBuffer): Promise<StudentData[]> => {

--- a/eis-tracker/app/api/import/route.ts
+++ b/eis-tracker/app/api/import/route.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import csv from 'csv-parser';
 import path from 'path';
 import Database from 'better-sqlite3';
+import { Readable } from 'stream';
 
 // Define the structure of the data we're interested in
 interface StudentData {
@@ -67,6 +68,43 @@ const extractDataFromCSV = async (filePath: string): Promise<StudentData[]> => {
     });
 };
 
+const extractDataFromBuffer = async (buffer: ArrayBuffer): Promise<StudentData[]> => {
+    const results: StudentData[] = [];
+    let firstRowProcessed = false;
+
+    return new Promise((resolve, reject) => {
+        const stream = Readable.from(Buffer.from(buffer)).pipe(csv());
+
+        stream
+            .on('data', (row: { [key: string]: string }) => {
+                if (!firstRowProcessed) {
+                    firstRowProcessed = true;
+                    return;
+                }
+
+                if (row['Student'] === 'Student, Test') return;
+
+                const fullName = row['Student'];
+                const [lastName, firstName] = fullName.split(',').map((n: string) => n.trim());
+
+                results.push({
+                    firstName: firstName || '',
+                    lastName: lastName || '',
+                    StudentID: row['SIS User ID'] || '',
+                    blueTag: Number(row['BLUE TAG  (228139)']) === 1,
+                    greenTag: Number(row['GREEN TAG (293966)']) === 100,
+                    orangeTag: Number(row['ORANGE TAG (294239)']) === 100,
+                    whiteTag: Number(row['Training Affirmation (Required)  (228040)']) === 100,
+                });
+            })
+            .on('end', () => {
+                results.pop(); // Remove test student
+                resolve(results);
+            })
+            .on('error', (err) => reject(err));
+    });
+};
+
 // Handle the POST request for file upload and CSV processing
 export async function POST(req: Request) {
 
@@ -81,24 +119,10 @@ export async function POST(req: Request) {
         return new Response(JSON.stringify({message: 'Invalid file upload'}), {status: 400});
     }
 
-    const filePath = `./.tmp/${file.name}`;
     const buffer = await file.arrayBuffer();
-    // await fs.promises.writeFile(filePath, Buffer.from(buffer));
-
-    const dirPath = path.dirname(filePath);
-    try {
-        await fs.promises.access(dirPath);
-    } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-            await fs.promises.mkdir(dirPath, {recursive: true});
-        } else {
-            throw error;
-        }
-    }
-    await fs.promises.writeFile(filePath, Buffer.from(buffer));
 
     try {
-        const data = await extractDataFromCSV(filePath);
+        const data = await extractDataFromBuffer(buffer);
         // Open the database connection
         const db = new Database('database/database.db');
 
@@ -170,14 +194,7 @@ export async function POST(req: Request) {
                 }
             }
         }
-        try {
-            if (true) { // Set to true to delete the file after processing
-                await fs.promises.unlink(filePath); // Delete the file after processing
-                await fs.promises.rm(dirPath, {recursive: true, force: true}); // Remove the directory if empty
-            }
-        } catch (err) {
-            console.error('Error deleting file:', err);
-        }
+
         return new Response(JSON.stringify({
             message: 'CSV imported successfully',
             added,


### PR DESCRIPTION
✅ Refactors the CSV import feature to use in-memory buffer streaming instead of writing temp files to disk.

Changes:
- Added `extractDataFromBuffer()` function using `Readable.from(buffer)` and `csv-parser`
- Modified the POST handler to parse uploaded CSV files directly from memory
- Removed temp `.tmp` file and directory creation
- Improves security (no lingering file artifacts)
- Improves compatibility with hosting environments like Vercel and the SDP server

✅ Acceptance Criteria:
- Uploading CSVs works correctly on the live server (no 500 error)
- No `.tmp` folder or manual file cleanup needed
- Large CSV files still process without crashing
- No maximum depth/infinite render errors after upload

Closes #176 