### PR TITLE
[#178] Display Accumulated Logged Hours on Student Display

### DIFF
--- a/eis-tracker/app/display/page.tsx
+++ b/eis-tracker/app/display/page.tsx
@@ -6,8 +6,9 @@ import Link from "next/link";
 interface Student {
     StudentID: string;
     First_Name: string;
-    Tags: string;
+    Tags: number;
     Logged_In: boolean;
+    TotalHours?: number;
 }
 
 export default function Dashboard() {
@@ -118,7 +119,7 @@ export default function Dashboard() {
         list
             .sort((a, b) => a.First_Name.localeCompare(b.First_Name))
             .map(student => {
-                const tags = parseInt(student.Tags, 10);
+                const tags = student.Tags;
                 console.log(`StudentID: ${student.StudentID}, Name: ${student.First_Name}, Tags (decimal): ${tags}, Tags (binary): ${tags.toString(2)}`
                 );
                 return(
@@ -135,7 +136,10 @@ export default function Dashboard() {
                     />
                     <div className="text-center mt-4">
                         <div className="text-xl font-bold">{student.First_Name}</div>
-                        <div className="mt-2 scale-125">{renderTags(parseInt(student.Tags))}</div>
+                        <div className="mt-2 scale-125">{renderTags(student.Tags)}</div>
+                        <div className="text-sm text-gray-600 mt-2">
+                            <strong>Hours:</strong> {student.TotalHours ?? "0.00"}
+                        </div>
                     </div>
                 </div>
                 )});

--- a/eis-tracker/app/page.tsx
+++ b/eis-tracker/app/page.tsx
@@ -41,8 +41,9 @@ export default function Home() {
     interface Student {
         StudentID: string;
         First_Name: string;
-        Tags: string;
+        Tags: number;
         Logged_In: boolean;
+        TotalHours: number;
     }
 
     const [loggedInStudents, setLoggedInStudents] = useState<Student[]>([]);
@@ -474,7 +475,7 @@ export default function Home() {
                                         </div>
                                         <div>
                                             <strong>Tags:</strong>
-                                            {renderTags(parseInt(student.Tags))}
+                                            {renderTags(student.Tags)}
                                         </div>
                                     </li>
                                 );


### PR DESCRIPTION
### Summary

This PR implements a feature that displays each student's total logged-in hours beneath their name and tag badges on the display page.

The hours are calculated using login/logout data from the `logs` table, including live sessions. The value is rounded to two decimal places and refreshes automatically with the display page’s polling interval.

### Changes Made

- **`app/api/db/route.ts`**  
  Added logic to calculate and round `TotalHours` using a `ROUND(SUM(...), 2)` SQL expression when querying `mode=all_logged_in`.

- **`app/display/page.tsx`**  
  Modified the student card UI to include a new section beneath tags that reads:  
  `Hours: 3.25`  
  This dynamically updates every 5 seconds.

- **`app/page.tsx`**  
  Removed the hours display from the login screen, as it's not needed there.

### Notes

- This prepares the backend and frontend for future enhancements (e.g., "Currently Logged In" text vs live timer).
- Purple tag support is already coded and ready, though not enabled yet.

---

Closes #178 